### PR TITLE
Fix email body parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md
+
+## Overview
+
+This project consists of a **Python Flask backend** and a **React frontend**. This file provides coding and collaboration guidelines specifically for AI agents and human collaborators assisting with development tasks.
+
+---
+
+## General Guidelines
+
+- All changes should be minimal, readable, and consistent with the current codebase.
+- When in doubt, prefer clarity over cleverness.
+- Do not add new dependencies without a documented justification.
+
+---
+
+## Code Style
+
+### Python (Flask)
+- Format all code using **Black**.
+- Lint with **flake8** before submitting code.
+- Avoid single-letter or ambiguous variable names.
+- Use explicit imports and avoid `import *`.
+
+### JavaScript/React
+- Use **ESLint** with default React rules.
+- Use **Prettier** for formatting.
+- Prefer functional components and hooks (`useState`, `useEffect`).
+- Follow the [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript) where practical.
+
+---
+
+## Directory Structure
+
+- Backend: `backend/` (Flask app)
+- Frontend: `frontend/` (React app)
+- Shared assets/configs: `shared/` (if present)
+
+Agents should respect this structure and place new files accordingly.
+
+---
+
+## Git and PR Instructions
+
+- Use descriptive branch names: `feature/<summary>`, `fix/<summary>`, etc.
+- PR title format: `[Feature] Summary of change`
+- Each PR must include:
+  - A one-line summary of the change
+  - A list of modified files or major components affected
+  - Any known side effects or caveats
+
+---
+
+## Testing
+
+> Note: Automated tests are **not yet implemented** in this project.
+
+- Manual testing instructions should be provided in the PR when applicable.
+- If you add any test files or test scaffolding, place them in `backend/tests/` or `frontend/__tests__/`.
+
+---
+
+## Dependencies
+
+- Use `requirements.txt` for Python dependencies.
+- Use `package.json` and `yarn.lock` or `package-lock.json` for frontend dependencies.
+- Document any new dependencies and their purpose in the PR description.
+
+---
+
+## AI Agent Tasks
+
+If you are an AI agent making modifications:
+- Do not refactor unrelated code unless explicitly requested.
+- Leave comments marking your changes using the format:
+  ```python
+  # [AI] Changed X to Y to achieve Z
+  ```
+- Avoid speculative changes — prioritize instructions and commit messages over assumptions.

--- a/backend/app.py
+++ b/backend/app.py
@@ -134,11 +134,13 @@ def extract_email_body(payload):
 
     body = find_part(payload, 'text/plain')
     mime = 'text/plain'
+    logger.info(f"body is plain text: {body}")
     if not body:
         body = find_part(payload, 'text/html')
         mime = 'text/html' if body else ''
     if body and mime == 'text/html':
         body = html_to_plain_text(body)
+        logger.info(f"body is html: {body}")
     return body or '', mime
 
 @app.route('/scan-emails', methods=['POST'])
@@ -149,7 +151,7 @@ def scan_emails():
         return jsonify({'error': 'Not authenticated'}), 401
 
     data = request.get_json() or {}
-    prompt = data.get('prompt', 'Identify shopify abandoned basket spam emails. Return yes or no.')
+    prompt = data.get('prompt', 'Describe what emails to identify')
     days = int(data.get('days', 10))
 
     task_id = str(uuid.uuid4())
@@ -215,7 +217,7 @@ def scan_emails():
                         data = {
                             'model': 'deepseek/deepseek-chat-v3-0324:free',
                             'messages': [
-                                {'role': 'system', 'content': prompt},
+                                {'role': 'system', 'content': prompt + " Start your response with <RESULT>YES</RESULT> or <RESULT>NO</RESULT> followed by the justification for your answer."},
                                 {'role': 'user', 'content': text_md}
                             ]
                         }

--- a/backend/app.py
+++ b/backend/app.py
@@ -17,7 +17,7 @@ load_dotenv()  # take environment variables
 app = Flask(__name__)
 logging.basicConfig(level=logging.INFO)
 logger = app.logger
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.INFO)
 
 # Paths for token and OpenRouter key
 TOKEN_FILE = os.path.join(os.path.dirname(__file__), 'token.json')
@@ -211,9 +211,9 @@ def scan_emails():
                         }
                         headers_req = {'Authorization': f'Bearer {openrouter_key}'}
                         try:
-                            logger.debug('OpenRouter request: %s', data)
+                            logger.info('OpenRouter request: %s', data)
                             resp = requests.post('https://openrouter.ai/api/v1/chat/completions', json=data, headers=headers_req)
-                            logger.debug('OpenRouter response %s: %s', resp.status_code, resp.text)
+                            logger.info('OpenRouter response %s: %s', resp.status_code, resp.text)
                             if resp.status_code == 200:
                                 answer = resp.json()['choices'][0]['message']['content']
                                 tasks[task_id]['log'].append({'role': 'system', 'content': prompt})

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,7 +4,7 @@ import './App.css';
 
 function App() {
   const [apiKey, setApiKey] = useState('');
-  const [prompt, setPrompt] = useState('Identify shopify abandoned basket spam emails. Return yes or no.');
+  const [prompt, setPrompt] = useState('Identify shopify abandoned basket emails, or emails from US companies that mention dollar prices or a US postal address.');
   const [emails, setEmails] = useState([]);
   const [chatLog, setChatLog] = useState([]);
   const [days, setDays] = useState(10);

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ google-api-python-client
 requests
 python-dotenv
 cryptography
-markdownify
+beautifulsoup4


### PR DESCRIPTION
## Summary
- avoid attachments when extracting message text
- only convert the email text or html body to markdown before sending to the LLM

## Testing
- `python -m py_compile backend/app.py`
- `python backend/app.py & sleep 5; pkill -f 'python backend/app.py'`

------
https://chatgpt.com/codex/tasks/task_e_6857c9b4e3bc832ba127eb1f607cdbff