### PR TITLE
CODEX: [Fix] UI polling persists

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -23,7 +23,7 @@
 *   Verify that the LLM correctly flags emails as YES or NO. (TODO)
 *   Verify that the LLM response can be parsed correctly. (TODO)
 
-#### User Story: View processed email data in a user interface (TODO)
+#### User Story: View processed email data in a user interface (DONE)
 **Description:** As a user, I want to view the processed email data and the results of the AI analysis in a clear and intuitive user interface.
 **Test Scenarios:**
 *   Verify that the UI displays a list of processed emails. (TODO)

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -2,3 +2,11 @@
 
 - Initial version of UI and Backend implemented.
 - Email body processing improvements.
+
+## 25th June 2025
+- Fixed polling in React frontend so scan status updates continuously.
+- Updated user story status in PROJECT_BACKLOG.md.
+
+## 26th June 2025
+- Reformatted backend with Black and frontend with Prettier.
+- Restored TODO status for UI test scenarios.

--- a/backend/app.py
+++ b/backend/app.py
@@ -13,6 +13,7 @@ from bs4 import BeautifulSoup
 import re
 
 from dotenv import load_dotenv
+
 load_dotenv()  # take environment variables
 
 app = Flask(__name__)
@@ -21,45 +22,50 @@ logger = app.logger
 logger.setLevel(logging.INFO)
 
 # Paths for token and OpenRouter key
-TOKEN_FILE = os.path.join(os.path.dirname(__file__), 'token.json')
-OPENROUTER_KEY_FILE = os.path.join(os.path.dirname(__file__), 'openrouter.key')
+TOKEN_FILE = os.path.join(os.path.dirname(__file__), "token.json")
+OPENROUTER_KEY_FILE = os.path.join(os.path.dirname(__file__), "openrouter.key")
 
 # in-memory store for background scan tasks
 tasks = {}
 
 # Google OAuth client credentials
-CLIENT_ID = os.environ.get('GOOGLE_CLIENT_ID')
-CLIENT_SECRET = os.environ.get('GOOGLE_CLIENT_SECRET')
+CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID")
+CLIENT_SECRET = os.environ.get("GOOGLE_CLIENT_SECRET")
 CLIENT_CONFIG = {
-    'web': {
-        'client_id': CLIENT_ID,
-        'client_secret': CLIENT_SECRET,
-        'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
-        'token_uri': 'https://oauth2.googleapis.com/token',
+    "web": {
+        "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
     }
 }
 
-SCOPES = ['https://www.googleapis.com/auth/gmail.modify']
+SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
 
-@app.route('/')
+
+@app.route("/")
 def root():
     return "hi"
 
-@app.route('/auth')
+
+@app.route("/auth")
 def auth():
-    frontend = os.environ.get('FRONTEND_URL', 'http://localhost:5173/')
+    frontend = os.environ.get("FRONTEND_URL", "http://localhost:5173/")
     print(f"frontend is {frontend}")
     flow = Flow.from_client_config(
         CLIENT_CONFIG,
         scopes=SCOPES,
         redirect_uri=(f"{frontend}/oauth2callback"),
     )
-    auth_url, _ = flow.authorization_url(access_type='offline', include_granted_scopes='true', prompt='consent')
+    auth_url, _ = flow.authorization_url(
+        access_type="offline", include_granted_scopes="true", prompt="consent"
+    )
     return redirect(auth_url)
 
-@app.route('/oauth2callback')
+
+@app.route("/oauth2callback")
 def oauth2callback():
-    frontend = os.environ.get('FRONTEND_URL', 'http://localhost:5173/')
+    frontend = os.environ.get("FRONTEND_URL", "http://localhost:5173/")
     print(f"frontend is {frontend}")
     flow = Flow.from_client_config(
         CLIENT_CONFIG,
@@ -68,16 +74,18 @@ def oauth2callback():
     )
     flow.fetch_token(authorization_response=request.url)
     creds = flow.credentials
-    with open(TOKEN_FILE, 'w') as f:
+    with open(TOKEN_FILE, "w") as f:
         f.write(creds.to_json())
     return redirect(frontend)
 
-@app.route('/openrouter-key', methods=['POST'])
+
+@app.route("/openrouter-key", methods=["POST"])
 def save_openrouter_key():
-    key = request.json.get('key')
-    with open(OPENROUTER_KEY_FILE, 'w') as f:
+    key = request.json.get("key")
+    with open(OPENROUTER_KEY_FILE, "w") as f:
         f.write(key)
-    return ('', 204)
+    return ("", 204)
+
 
 def get_credentials():
     if not os.path.exists(TOKEN_FILE):
@@ -85,23 +93,32 @@ def get_credentials():
     try:
         with open(TOKEN_FILE) as f:
             info = json.load(f)
-        if 'refresh_token' not in info:
-            logger.warning('token.json missing refresh_token')
+        if "refresh_token" not in info:
+            logger.warning("token.json missing refresh_token")
             return None
         creds = Credentials.from_authorized_user_info(info, SCOPES)
         return creds
     except Exception as e:
-        logger.error('Failed to load credentials: %s', e)
+        logger.error("Failed to load credentials: %s", e)
         return None
 
+
 def get_label_id(service, name):
-    labels = service.users().labels().list(userId='me').execute().get('labels', [])
+    labels = (
+        service.users().labels().list(userId="me").execute().get("labels", [])
+    )
     for lbl in labels:
-        if lbl['name'].lower() == name.lower():
-            return lbl['id']
+        if lbl["name"].lower() == name.lower():
+            return lbl["id"]
     # create label if not exists
-    label = service.users().labels().create(userId='me', body={'name': name}).execute()
-    return label['id']
+    label = (
+        service.users()
+        .labels()
+        .create(userId="me", body={"name": name})
+        .execute()
+    )
+    return label["id"]
+
 
 # Recursively extract the text or html body from a message payload.
 def extract_email_body(payload):
@@ -109,208 +126,380 @@ def extract_email_body(payload):
 
     def collect_parts(part, results):
         if (
-            part.get('mimeType') in ('text/plain', 'text/html')
-            and not part.get('filename')
-            and 'body' in part
+            part.get("mimeType") in ("text/plain", "text/html")
+            and not part.get("filename")
+            and "body" in part
         ):
-            data = part['body'].get('data')
+            data = part["body"].get("data")
             if data:
-                text = base64.urlsafe_b64decode(data).decode('utf-8', errors='ignore')
-                results.append((text, part.get('mimeType')))
-        for sub in part.get('parts', []):
+                text = base64.urlsafe_b64decode(data).decode(
+                    "utf-8", errors="ignore"
+                )
+                results.append((text, part.get("mimeType")))
+        for sub in part.get("parts", []):
             collect_parts(sub, results)
 
     def html_to_plain_text(html: str) -> str:
         """Convert HTML to plain text stripping formatting and links."""
-        soup = BeautifulSoup(html, 'html.parser')
-        for a in soup.find_all('a'):
+        soup = BeautifulSoup(html, "html.parser")
+        for a in soup.find_all("a"):
             a.replace_with(a.get_text())
-        text = soup.get_text(separator=' ')
-        text = re.sub(r'\s+', ' ', text)
+        text = soup.get_text(separator=" ")
+        text = re.sub(r"\s+", " ", text)
         return text.strip()
 
     parts = []
     collect_parts(payload, parts)
 
-    html_part = next((t for t, m in parts if m == 'text/html'), None)
+    html_part = next((t for t, m in parts if m == "text/html"), None)
     if html_part:
         body = html_to_plain_text(html_part)
         logger.info(f"body is html: {body}")
-        return body, 'text/html'
+        return body, "text/html"
 
-    text_part = next((t for t, m in parts if m == 'text/plain'), None)
+    text_part = next((t for t, m in parts if m == "text/plain"), None)
     if text_part:
-        text_part = re.sub(r'https?://\S+', '', text_part)
-        text_part = re.sub(r'\s+', ' ', text_part).strip()
+        text_part = re.sub(r"https?://\S+", "", text_part)
+        text_part = re.sub(r"\s+", " ", text_part).strip()
         logger.info(f"body is plaintext: {text_part}")
-        return text_part, 'text/plain'
+        return text_part, "text/plain"
 
-    return '', ''
+    return "", ""
 
-@app.route('/scan-emails', methods=['POST'])
+
+@app.route("/scan-emails", methods=["POST"])
 def scan_emails():
     """Start a background scan task and return its id"""
     creds = get_credentials()
     if not creds:
-        return jsonify({'error': 'Not authenticated'}), 401
+        return jsonify({"error": "Not authenticated"}), 401
 
     data = request.get_json() or {}
-    prompt = data.get('prompt', 'Describe what emails to identify')
-    days = int(data.get('days', 10))
+    prompt = data.get("prompt", "Describe what emails to identify")
+    days = int(data.get("days", 10))
 
     task_id = str(uuid.uuid4())
-    tasks[task_id] = {'stage': 'queued', 'progress': 0, 'total': 0, 'emails': [], 'log': []}
-    logger.info('Starting scan task %s for last %s days', task_id, days)
+    tasks[task_id] = {
+        "stage": "queued",
+        "progress": 0,
+        "total": 0,
+        "emails": [],
+        "log": [],
+    }
+    logger.info("Starting scan task %s for last %s days", task_id, days)
 
     def worker():
         try:
-            whitelist=set()
-            service = build('gmail', 'v1', credentials=creds)
-            spam_label = get_label_id(service, 'shopify-spam')
-            whitelist_label = get_label_id(service, 'whitelist')
+            whitelist = set()
+            service = build("gmail", "v1", credentials=creds)
+            spam_label = get_label_id(service, "shopify-spam")
+            whitelist_label = get_label_id(service, "whitelist")
             # gather whitelisted senders
-            logger.debug('Gmail request: list whitelist emails')
-            result = service.users().messages().list(userId='me', q='label:whitelist').execute()
-            logger.debug('Gmail response: %s', result)
-            if (result.get('resultSizeEstimate', 1) != 0):
-                wmsgs = result.get('messages', [])
+            logger.debug("Gmail request: list whitelist emails")
+            result = (
+                service.users()
+                .messages()
+                .list(userId="me", q="label:whitelist")
+                .execute()
+            )
+            logger.debug("Gmail response: %s", result)
+            if result.get("resultSizeEstimate", 1) != 0:
+                wmsgs = result.get("messages", [])
                 for idx, m in enumerate(wmsgs):
-                    logger.debug('Gmail request: get message %s for whitelist', m['id'])
-                    md = service.users().messages().get(userId='me', id=m['id'], format='metadata', metadataHeaders=['From']).execute()
-                    logger.debug('Gmail response: %s', md)
-                    sender = next((h['value'] for h in md['payload']['headers'] if h['name'].lower() == 'from'), '')
+                    logger.debug(
+                        "Gmail request: get message %s for whitelist", m["id"]
+                    )
+                    md = (
+                        service.users()
+                        .messages()
+                        .get(
+                            userId="me",
+                            id=m["id"],
+                            format="metadata",
+                            metadataHeaders=["From"],
+                        )
+                        .execute()
+                    )
+                    logger.debug("Gmail response: %s", md)
+                    sender = next(
+                        (
+                            h["value"]
+                            for h in md["payload"]["headers"]
+                            if h["name"].lower() == "from"
+                        ),
+                        "",
+                    )
                     whitelist.add(sender)
 
+            tasks[task_id]["stage"] = "fetching"
 
-            tasks[task_id]['stage'] = 'fetching'
+            query = f"after:{days}d"
 
-            query=f"after:{days}d"
-
-            results = service.users().messages().list(userId='me', q=query).execute()
-            logger.debug('Gmail response: %s', results)
-            messages = results.get('messages', [])
-            tasks[task_id]['total'] = len(messages)
-            openrouter_key = ''
+            results = (
+                service.users().messages().list(userId="me", q=query).execute()
+            )
+            logger.debug("Gmail response: %s", results)
+            messages = results.get("messages", [])
+            tasks[task_id]["total"] = len(messages)
+            openrouter_key = ""
             if os.path.exists(OPENROUTER_KEY_FILE):
                 with open(OPENROUTER_KEY_FILE) as f:
                     openrouter_key = f.read().strip()
 
             for idx, msg in enumerate(messages):
-                tasks[task_id]['stage'] = 'processing'
-                tasks[task_id]['progress'] = idx
-                logger.debug('Gmail request: get message %s', msg['id'])
-                msg_detail = service.users().messages().get(userId='me', id=msg['id'], format='full').execute()
-                logger.debug('Gmail response: %s', msg_detail)
-                payload = msg_detail.get('payload', {})
-                headers = payload.get('headers', [])
-                subject = next((h['value'] for h in headers if h['name'].lower() == 'subject'), '')
-                sender = next((h['value'] for h in headers if h['name'].lower() == 'from'), '')
-                date = next((h['value'] for h in headers if h['name'].lower() == 'date'), '')
-                label_ids = msg_detail.get('labelIds', [])
+                tasks[task_id]["stage"] = "processing"
+                tasks[task_id]["progress"] = idx
+                logger.debug("Gmail request: get message %s", msg["id"])
+                msg_detail = (
+                    service.users()
+                    .messages()
+                    .get(userId="me", id=msg["id"], format="full")
+                    .execute()
+                )
+                logger.debug("Gmail response: %s", msg_detail)
+                payload = msg_detail.get("payload", {})
+                headers = payload.get("headers", [])
+                subject = next(
+                    (
+                        h["value"]
+                        for h in headers
+                        if h["name"].lower() == "subject"
+                    ),
+                    "",
+                )
+                sender = next(
+                    (
+                        h["value"]
+                        for h in headers
+                        if h["name"].lower() == "from"
+                    ),
+                    "",
+                )
+                date = next(
+                    (
+                        h["value"]
+                        for h in headers
+                        if h["name"].lower() == "date"
+                    ),
+                    "",
+                )
+                label_ids = msg_detail.get("labelIds", [])
 
                 body, _ = extract_email_body(payload)
                 words = body.split()
-                body_preview = ' '.join(words[:500])
-                text_md = f"Subject: {subject}\nFrom: {sender}\n\n{body_preview}"
+                body_preview = " ".join(words[:500])
+                text_md = (
+                    f"Subject: {subject}\nFrom: {sender}\n\n{body_preview}"
+                )
 
-                status = 'not_spam'
+                status = "not_spam"
                 if whitelist_label in label_ids or sender in whitelist:
-                    status = 'whitelist'
+                    status = "whitelist"
                 else:
                     if openrouter_key:
                         data = {
-                            'model': 'deepseek/deepseek-chat-v3-0324:free',
-                            'messages': [
-                                {'role': 'system', 'content': prompt + " Start your response with <RESULT>YES</RESULT> or <RESULT>NO</RESULT> followed by the justification for your answer."},
-                                {'role': 'user', 'content': text_md}
-                            ]
+                            "model": "deepseek/deepseek-chat-v3-0324:free",
+                            "messages": [
+                                {
+                                    "role": "system",
+                                    "content": (
+                                        prompt
+                                        + (
+                                            " Start your response with "
+                                            "<RESULT>YES</RESULT> or "
+                                            "<RESULT>NO</RESULT> followed by "
+                                            "the justification for "
+                                            "your answer."
+                                        )
+                                    ),
+                                },
+                                {"role": "user", "content": text_md},
+                            ],
                         }
-                        headers_req = {'Authorization': f'Bearer {openrouter_key}'}
+                        headers_req = {
+                            "Authorization": f"Bearer {openrouter_key}"
+                        }
                         try:
-                            logger.info('OpenRouter request: %s', data)
-                            resp = requests.post('https://openrouter.ai/api/v1/chat/completions', json=data, headers=headers_req)
-                            logger.info('OpenRouter response %s: %s', resp.status_code, resp.text)
+                            logger.info("OpenRouter request: %s", data)
+                            resp = requests.post(
+                                "https://openrouter.ai/api/v1/"
+                                "chat/completions",
+                                json=data,
+                                headers=headers_req,
+                            )
+                            logger.info(
+                                "OpenRouter response %s: %s",
+                                resp.status_code,
+                                resp.text,
+                            )
                             if resp.status_code == 200:
-                                answer = resp.json()['choices'][0]['message']['content']
-                                tasks[task_id]['log'].append({'role': 'system', 'content': prompt})
-                                tasks[task_id]['log'].append({'role': 'user', 'content': text_md})
-                                tasks[task_id]['log'].append({'role': 'assistant', 'content': answer})
-                                if 'yes' in answer.lower():
-                                    status = 'spam'
+                                answer = resp.json()["choices"][0]["message"][
+                                    "content"
+                                ]
+                                tasks[task_id]["log"].append(
+                                    {"role": "system", "content": prompt}
+                                )
+                                tasks[task_id]["log"].append(
+                                    {"role": "user", "content": text_md}
+                                )
+                                tasks[task_id]["log"].append(
+                                    {"role": "assistant", "content": answer}
+                                )
+                                if "yes" in answer.lower():
+                                    status = "spam"
                             else:
-                                logger.error('OpenRouter error: %s - %s', resp.status_code, resp.text)
+                                logger.error(
+                                    "OpenRouter error: %s - %s",
+                                    resp.status_code,
+                                    resp.text,
+                                )
                         except Exception:
                             pass
 
-                if status == 'spam':
-                    logger.debug('Gmail request: add spam label to %s', msg['id'])
-                    service.users().messages().modify(userId='me', id=msg['id'], body={'addLabelIds': [spam_label], 'removeLabelIds': [whitelist_label]}).execute()
-                elif status == 'whitelist':
-                    logger.debug('Gmail request: add whitelist label to %s', msg['id'])
-                    service.users().messages().modify(userId='me', id=msg['id'], body={'addLabelIds': [whitelist_label], 'removeLabelIds': [spam_label]}).execute()
+                if status == "spam":
+                    logger.debug(
+                        "Gmail request: add spam label to %s", msg["id"]
+                    )
+                    service.users().messages().modify(
+                        userId="me",
+                        id=msg["id"],
+                        body={
+                            "addLabelIds": [spam_label],
+                            "removeLabelIds": [whitelist_label],
+                        },
+                    ).execute()
+                elif status == "whitelist":
+                    logger.debug(
+                        "Gmail request: add whitelist label to %s", msg["id"]
+                    )
+                    service.users().messages().modify(
+                        userId="me",
+                        id=msg["id"],
+                        body={
+                            "addLabelIds": [whitelist_label],
+                            "removeLabelIds": [spam_label],
+                        },
+                    ).execute()
 
-                tasks[task_id]['emails'].append({'id': msg['id'], 'subject': subject, 'sender': sender, 'date': date, 'status': status})
+                tasks[task_id]["emails"].append(
+                    {
+                        "id": msg["id"],
+                        "subject": subject,
+                        "sender": sender,
+                        "date": date,
+                        "status": status,
+                    }
+                )
 
-            tasks[task_id]['progress'] = tasks[task_id]['total']
-            tasks[task_id]['stage'] = 'done'
+            tasks[task_id]["progress"] = tasks[task_id]["total"]
+            tasks[task_id]["stage"] = "done"
         except Exception:
             import traceback
+
             print(traceback.format_exc())
 
     threading.Thread(target=worker).start()
-    return jsonify({'task_id': task_id})
+    return jsonify({"task_id": task_id})
 
-@app.route('/scan-status/<task_id>')
+
+@app.route("/scan-status/<task_id>")
 def scan_status(task_id):
     task = tasks.get(task_id)
     if not task:
-        return jsonify({'error': 'not found'}), 404
+        return jsonify({"error": "not found"}), 404
     return jsonify(task)
 
-@app.route('/update-status', methods=['POST'])
+
+@app.route("/update-status", methods=["POST"])
 def update_status():
     creds = get_credentials()
     if not creds:
-        return jsonify({'error': 'Not authenticated'}), 401
-    service = build('gmail', 'v1', credentials=creds)
-    msg_id = request.json['id']
-    status = request.json['status']
-    spam_label = get_label_id(service, 'shopify-spam')
-    whitelist_label = get_label_id(service, 'whitelist')
-    logger.info('Update status request for %s -> %s', msg_id, status)
-    if status == 'spam':
-        logger.debug('Gmail request: add spam label to %s', msg_id)
-        service.users().messages().modify(userId='me', id=msg_id, body={'addLabelIds': [spam_label], 'removeLabelIds': [whitelist_label]}).execute()
-    elif status == 'whitelist':
-        logger.debug('Gmail request: add whitelist label to %s', msg_id)
-        service.users().messages().modify(userId='me', id=msg_id, body={'addLabelIds': [whitelist_label], 'removeLabelIds': [spam_label]}).execute()
+        return jsonify({"error": "Not authenticated"}), 401
+    service = build("gmail", "v1", credentials=creds)
+    msg_id = request.json["id"]
+    status = request.json["status"]
+    spam_label = get_label_id(service, "shopify-spam")
+    whitelist_label = get_label_id(service, "whitelist")
+    logger.info("Update status request for %s -> %s", msg_id, status)
+    if status == "spam":
+        logger.debug("Gmail request: add spam label to %s", msg_id)
+        service.users().messages().modify(
+            userId="me",
+            id=msg_id,
+            body={
+                "addLabelIds": [spam_label],
+                "removeLabelIds": [whitelist_label],
+            },
+        ).execute()
+    elif status == "whitelist":
+        logger.debug("Gmail request: add whitelist label to %s", msg_id)
+        service.users().messages().modify(
+            userId="me",
+            id=msg_id,
+            body={
+                "addLabelIds": [whitelist_label],
+                "removeLabelIds": [spam_label],
+            },
+        ).execute()
     else:
-        logger.debug('Gmail request: clear spam/whitelist labels from %s', msg_id)
-        service.users().messages().modify(userId='me', id=msg_id, body={'removeLabelIds': [spam_label, whitelist_label]}).execute()
-    return ('', 204)
+        logger.debug(
+            "Gmail request: clear spam/whitelist labels from %s", msg_id
+        )
+        service.users().messages().modify(
+            userId="me",
+            id=msg_id,
+            body={"removeLabelIds": [spam_label, whitelist_label]},
+        ).execute()
+    return ("", 204)
 
-@app.route('/confirm', methods=['POST'])
+
+@app.route("/confirm", methods=["POST"])
 def confirm():
     creds = get_credentials()
     if not creds:
-        return jsonify({'error': 'Not authenticated'}), 401
-    service = build('gmail', 'v1', credentials=creds)
-    logger.info('Confirming %s messages as spam', len(request.json.get('ids', [])))
-    ids = request.json.get('ids', [])
+        return jsonify({"error": "Not authenticated"}), 401
+    service = build("gmail", "v1", credentials=creds)
+    logger.info(
+        "Confirming %s messages as spam", len(request.json.get("ids", []))
+    )
+    ids = request.json.get("ids", [])
     for msg_id in ids:
-        logger.debug('Gmail request: get message %s for confirmation', msg_id)
-        msg = service.users().messages().get(userId='me', id=msg_id, format='metadata', metadataHeaders=['From']).execute()
-        logger.debug('Gmail response: %s', msg)
-        sender = next((h['value'] for h in msg['payload']['headers'] if h['name'].lower() == 'from'), '')
+        logger.debug("Gmail request: get message %s for confirmation", msg_id)
+        msg = (
+            service.users()
+            .messages()
+            .get(
+                userId="me",
+                id=msg_id,
+                format="metadata",
+                metadataHeaders=["From"],
+            )
+            .execute()
+        )
+        logger.debug("Gmail response: %s", msg)
+        sender = next(
+            (
+                h["value"]
+                for h in msg["payload"]["headers"]
+                if h["name"].lower() == "from"
+            ),
+            "",
+        )
         # Add to block list
-        logger.debug('Gmail request: create filter for %s', sender)
-        service.users().settings().filters().create(userId='me', body={
-            'criteria': {'from': sender},
-            'action': {'addLabelIds': ['SPAM'], 'removeLabelIds': []}
-        }).execute()
-        logger.debug('Gmail request: add SPAM label to %s', msg_id)
-        service.users().messages().modify(userId='me', id=msg_id, body={'addLabelIds': ['SPAM']}).execute()
-    return ('', 204)
+        logger.debug("Gmail request: create filter for %s", sender)
+        service.users().settings().filters().create(
+            userId="me",
+            body={
+                "criteria": {"from": sender},
+                "action": {"addLabelIds": ["SPAM"], "removeLabelIds": []},
+            },
+        ).execute()
+        logger.debug("Gmail request: add SPAM label to %s", msg_id)
+        service.users().messages().modify(
+            userId="me", id=msg_id, body={"addLabelIds": ["SPAM"]}
+        ).execute()
+    return ("", 204)
 
-if __name__ == '__main__':
-    app.run(debug=True, ssl_context='adhoc')
+
+if __name__ == "__main__":
+    app.run(debug=True, ssl_context="adhoc")


### PR DESCRIPTION
## Summary
- preserve task ID during polling so updates continue
- reformat backend with Black (line length 79) and frontend with Prettier
- restore TODO status for UI test scenarios
- log the formatting fix

## User Stories
- View processed email data in a user interface

## Modified Files
- `PROJECT_BACKLOG.md`
- `WORK_LOG.md`
- `backend/app.py`
- `frontend/src/main.jsx`

## Side Effects
- ESLint failed due to missing configuration

## Testing
- `black --check --line-length 79 backend/app.py`
- `flake8 backend/app.py`
- `npx prettier -c frontend/src/main.jsx`
- `npx eslint frontend/src/main.jsx` *(fails: missing config)*

------
https://chatgpt.com/codex/tasks/task_e_685b95754b0c832bbf4f9458771664b5