### PR TITLE
CODEX: [Fix] confirm uses custom spam label

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -45,6 +45,15 @@
 - Mark an email as ignore and verify the "spam-filter-ignore" label is added. (TODO)
 - New emails from the ignored sender are automatically marked as ignored. (TODO)
 
+#### User Story: Confirm spam emails without SPAM label (DONE)
+
+**Description:** As a user, I want confirming spam emails to label them `shopify-spam` and remove them from the inbox because Gmail's API does not allow adding the `SPAM` label directly.
+
+**Test Scenarios:**
+
+- Confirming a spam email adds the `shopify-spam` label and removes the `INBOX` label. (TODO)
+- A filter is created to automatically label future emails from the sender with `shopify-spam`. (TODO)
+
 #### User Story: Improved UI styling (TODO)
 
 **Description:** As a user, I want chat messages shown as speech bubbles with expandable content and color-coded results, and email rows highlighted based on status for easier review.

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ This project contains a simple Flask backend and React frontend to scan your Gma
 
 To create a production build of the frontend, run `npm run build` inside `frontend/` and serve the generated `dist` directory.
 
-Spam results are stored using the `shopify-spam` label in Gmail. Confirming choices will block senders and mark messages as spam in Gmail.
+Spam results are stored using the `shopify-spam` label in Gmail. Confirming choices will label messages as `shopify-spam` and remove them from the inbox.

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -19,3 +19,5 @@
 
 - Reduced chat log text size to 75% for compact bubbles.
 - Documented new test scenario for smaller chat text.
+- Adjusted confirm endpoint to label spam using `shopify-spam` and remove `INBOX` label.
+- Updated README and added user story for confirmation workflow.

--- a/backend/app.py
+++ b/backend/app.py
@@ -40,7 +40,10 @@ CLIENT_CONFIG = {
     }
 }
 
-SCOPES = ["https://www.googleapis.com/auth/gmail.modify", "https://www.googleapis.com/auth/gmail.settings.basic"]
+SCOPES = [
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.settings.basic",
+]
 
 
 @app.route("/")
@@ -484,6 +487,7 @@ def confirm():
         return jsonify({"error": "Not authenticated"}), 401
     service = build("gmail", "v1", credentials=creds)
     logger.info("Confirming %s messages as spam", len(request.json.get("ids", [])))
+    spam_label = get_label_id(service, "shopify-spam")
     ids = request.json.get("ids", [])
     for msg_id in ids:
         logger.debug("Gmail request: get message %s for confirmation", msg_id)
@@ -513,12 +517,17 @@ def confirm():
             userId="me",
             body={
                 "criteria": {"from": sender},
-                "action": {"addLabelIds": ["SPAM"], "removeLabelIds": []},
+                "action": {
+                    "addLabelIds": [spam_label],
+                    "removeLabelIds": ["INBOX"],
+                },
             },
         ).execute()
-        logger.debug("Gmail request: add SPAM label to %s", msg_id)
+        logger.debug("Gmail request: label %s as shopify-spam", msg_id)
         service.users().messages().modify(
-            userId="me", id=msg_id, body={"addLabelIds": ["SPAM"]}
+            userId="me",
+            id=msg_id,
+            body={"addLabelIds": [spam_label], "removeLabelIds": ["INBOX"]},
         ).execute()
     return ("", 204)
 


### PR DESCRIPTION
## Summary
- avoid Gmail API error by not applying the `SPAM` label
- update confirmation flow to add `shopify-spam` label and remove `INBOX`
- document confirmation behavior in README
- add user story for confirmation workflow
- log today's work

## User Stories Implemented
- Confirm spam emails without SPAM label

## Affected Files
- `backend/app.py`
- `README.md`
- `PROJECT_BACKLOG.md`
- `WORK_LOG.md`

## Known Side Effects
- None

## Testing
- `black backend/app.py`
- `flake8`
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685cee1b2f74832b8c6c9a55403419ca