### PR TITLE
CODEX: [Feature] Clean chat log display

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -54,3 +54,13 @@
 - Assistant replies show red background for YES and green background for NO. (TODO)
 - Email list rows have coloured backgrounds matching their status. (TODO)
 - Chat log uses smaller font size for compact display. (TODO)
+
+#### User Story: Clean chat log display (TODO)
+
+**Description:** As a user, I want the chat log to hide system prompts and strip
+result tags from assistant replies so that the conversation is easier to read.
+
+**Test Scenarios:**
+
+- System messages are not displayed in the chat log. (TODO)
+- <RESULT> tags are removed from assistant replies. (TODO)

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -19,3 +19,5 @@
 
 - Reduced chat log text size to 75% for compact bubbles.
 - Documented new test scenario for smaller chat text.
+- Hid system prompts and stripped <RESULT> tags in chat log.
+- Added new user story for clean chat display.

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,11 +3,12 @@ import ReactDOM from "react-dom/client";
 import "./App.css";
 
 function ChatBubble({ role, content }) {
+  const clean = content.replace(/<\/?RESULT>/gi, "");
   const [expanded, setExpanded] = useState(false);
-  const sentences = content.split(/(?<=[.!?])\s+/);
+  const sentences = clean.split(/(?<=[.!?])\s+/);
   const preview = sentences.slice(0, 3).join(" ");
   const isLong = sentences.length > 3;
-  const display = expanded || !isLong ? content : preview;
+  const display = expanded || !isLong ? clean : preview;
 
   let extraClass = "";
   if (role === "assistant") {
@@ -201,9 +202,11 @@ function App() {
         <button onClick={confirm}>Confirm Choices</button>
       </div>
       <div className="chat-log">
-        {chatLog.map((c, i) => (
-          <ChatBubble key={i} role={c.role} content={c.content} />
-        ))}
+        {chatLog
+          .filter((c) => c.role !== "system")
+          .map((c, i) => (
+            <ChatBubble key={i} role={c.role} content={c.content} />
+          ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- strip <RESULT> tags before showing assistant replies
- hide system messages from chat window
- log update and backlog entry for clean chat display

## User Stories
- Clean chat log display (TODO)

## Modified Files
- `frontend/src/main.jsx`
- `PROJECT_BACKLOG.md`
- `WORK_LOG.md`

## Known Side Effects
- eslint fails to run due to missing configuration

## Testing
- `npx prettier -w WORK_LOG.md PROJECT_BACKLOG.md`
- `npx prettier -w frontend/src/main.jsx`
- `npx eslint frontend/src/main.jsx` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_685cee937e2c832b98d96fc8e4af9925