### PR TITLE
CODEX: [Feature] Resume active scan tasks

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -92,3 +92,11 @@ result tags from assistant replies so that the conversation is easier to read.
 - More than 100 results are returned when querying messages and all are processed. (TODO)
 - Whitelist and ignore lists are fully retrieved across pages. (TODO)
 
+#### User Story: Resume active scan tasks (TODO)
+
+**Description:** As a user, I want the app to detect any running scan tasks when I reload the page so that I can continue watching progress without starting a new scan.
+
+**Test Scenarios:**
+
+- Reloading the page during a scan resumes polling and shows current progress. (TODO)
+

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ This project contains a simple Flask backend and React frontend to scan your Gma
 ## Setup
 
 1. Obtain Google OAuth credentials and set them as environment variables:
+
    1. Go to the [Google Cloud Console](https://console.cloud.google.com/).
    2. Create a project and enable the **Gmail API**.
    3. Configure the OAuth consent screen (External user type is sufficient).
    4. Create **OAuth client ID** credentials of type **Web application** and add
       `http://localhost:5000/oauth2callback` as an authorised redirect URI.
-   5. Copy the generated *Client ID* and *Client Secret* and export them before
+   5. Copy the generated _Client ID_ and _Client Secret_ and export them before
       running the backend:
       ```bash
       export GOOGLE_CLIENT_ID=<client-id>
@@ -19,6 +20,7 @@ This project contains a simple Flask backend and React frontend to scan your Gma
    6. Add your gmail account to the list of "test users" within the OAuth Client settings in the Audience tab.
 
    When you start the app it will redirect you to Google to grant Gmail access.
+
 2. Install Python dependencies:
    ```bash
    pip install -r requirements.txt
@@ -34,7 +36,7 @@ This project contains a simple Flask backend and React frontend to scan your Gma
    python backend/app.py
    ```
    Set `FRONTEND_URL` if your React dev server runs on a different URL (default `http://localhost:5173/`).
-5. Open the URL shown by the dev server in your browser. Link your Gmail account, enter your OpenRouter API key and scan emails.
+5. Open the URL shown by the dev server in your browser. Link your Gmail account, enter your OpenRouter API key and scan emails. If you reload the page while a scan is running, the app will reconnect and keep showing progress.
 
 To create a production build of the frontend, run `npm run build` inside `frontend/` and serve the generated `dist` directory.
 

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -31,3 +31,10 @@
 - Refactored Gmail listing to handle pagination with list_all_messages helper.
 - Added pagination user story to PROJECT_BACKLOG.
 
+## 27th June 2025
+
+- Added backend endpoint `/scan-tasks` to list running scan tasks.
+- Frontend now checks for active tasks on load and resumes polling every second.
+- Proxied new endpoint through Vite config.
+- Documented new user story for resuming tasks in PROJECT_BACKLOG.
+

--- a/backend/app.py
+++ b/backend/app.py
@@ -304,9 +304,8 @@ def scan_emails():
 
             query = f"after:{date_after.strftime('%Y-%m-%d')} in:inbox is:unread label:inbox"
 
-
             messages = list_all_messages(service, q=query)
-            
+
             tasks[task_id]["total"] = len(messages)
             logger.info("messages length is currently %d ", tasks[task_id]["total"])
             openrouter_key = ""
@@ -475,6 +474,17 @@ def scan_status(task_id):
     if not task:
         return jsonify({"error": "not found"}), 404
     return jsonify(task)
+
+
+# CODEX: Endpoint to list active scan tasks
+@app.route("/scan-tasks")
+def scan_tasks():
+    active = [
+        {"id": tid, **info}
+        for tid, info in tasks.items()
+        if info.get("stage") != "done"
+    ]
+    return jsonify({"tasks": active})
 
 
 @app.route("/update-status", methods=["POST"])

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -54,6 +54,20 @@ function App() {
       .catch(() => {
         setPrompt(DEFAULT_PROMPT);
       });
+
+    // CODEX: Check for any running tasks when the page loads
+    fetch("/scan-tasks")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.tasks && d.tasks.length > 0) {
+          const t = d.tasks[0];
+          setTask({ id: t.id, ...t });
+          setEmails(t.emails || []);
+          setChatLog(t.log || []);
+          setPollInterval(1);
+        }
+      })
+      .catch(() => {});
   }, []);
 
   const linkGmail = () => {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -41,6 +41,12 @@ export default defineConfig({
         secure: false,
         agent: httpsAgent,
       },
+      "/scan-tasks": {
+        target: backend,
+        changeOrigin: true,
+        secure: false,
+        agent: httpsAgent,
+      },
       "/update-status": {
         target: backend,
         changeOrigin: true,


### PR DESCRIPTION
## Summary
- expose `/scan-tasks` endpoint to list running tasks
- resume polling on page load if a scan task is active
- proxy new endpoint through Vite
- update documentation and backlog
- log work for 27th June 2025

## User Stories
- Resume active scan tasks (TODO)

## Affected Files
- `backend/app.py`
- `frontend/src/main.jsx`
- `frontend/vite.config.js`
- `README.md`
- `PROJECT_BACKLOG.md`
- `WORK_LOG.md`

## Known Side Effects
- none

## Testing
- `flake8 backend/app.py`
- `npx prettier -w frontend/src/main.jsx frontend/vite.config.js README.md`


------
https://chatgpt.com/codex/tasks/task_e_685e3e0a634c832bad2455be7c3f1059