### PR TITLE
CODEX: [Fix] persist manual email status changes

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -100,3 +100,11 @@ result tags from assistant replies so that the conversation is easier to read.
 
 - Reloading the page during a scan resumes polling and shows current progress. (TODO)
 
+#### User Story: Persist manual status updates during scans (DONE)
+
+**Description:** As a user, I want any status changes I make while a scan is running to remain saved so that the emails do not revert on the next refresh.
+
+**Test Scenarios:**
+
+- Changing an email status while a scan is running persists when the task status is fetched. (TODO)
+

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -38,3 +38,10 @@
 - Proxied new endpoint through Vite config.
 - Documented new user story for resuming tasks in PROJECT_BACKLOG.
 
+## 28th June 2025
+
+- Fixed issue where email status changes during a running scan were lost on refresh.
+- Added `update_task_email_status` helper to persist manual updates.
+- Updated `/update-status` and `/confirm` endpoints to modify running task data.
+- Documented new user story about persisting status updates in PROJECT_BACKLOG.
+

--- a/backend/app.py
+++ b/backend/app.py
@@ -32,6 +32,16 @@ PROMPT_FILE = os.path.join(os.path.dirname(__file__), "last_prompt.json")
 # in-memory store for background scan tasks
 tasks = {}
 
+
+def update_task_email_status(msg_id: str, status: str) -> None:
+    """Update status of a message within any running scan task."""
+    for info in tasks.values():
+        for email in info.get("emails", []):
+            if email.get("id") == msg_id:
+                # CODEX: Persist manual status updates during a scan
+                email["status"] = status
+
+
 # Google OAuth client credentials
 CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID")
 CLIENT_SECRET = os.environ.get("GOOGLE_CLIENT_SECRET")
@@ -538,6 +548,7 @@ def update_status():
             id=msg_id,
             body={"removeLabelIds": [spam_label, whitelist_label, ignore_label]},
         ).execute()
+    update_task_email_status(msg_id, status)
     return ("", 204)
 
 
@@ -590,6 +601,7 @@ def confirm():
             id=msg_id,
             body={"addLabelIds": [spam_label], "removeLabelIds": ["INBOX"]},
         ).execute()
+        update_task_email_status(msg_id, "spam")
     return ("", 204)
 
 


### PR DESCRIPTION
## Summary
- ensure status changes update running task data
- add user story for persisting manual status updates
- log work for this fix

## User Stories
- Persist manual status updates during scans (DONE)

## Modified Files
- `backend/app.py`
- `PROJECT_BACKLOG.md`
- `WORK_LOG.md`

## Testing
- `black backend/app.py`
- `flake8 backend/app.py` *(fails: E501 line too long)*
- `npx prettier -w frontend/src/main.jsx`
- `npx eslint frontend/src/main.jsx` *(fails: couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_685f7b56f374832ba98cd2e4f946fdf6