### PR TITLE
CODEX: [Feature] detailed fetch progress and confirm state

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -117,3 +117,13 @@ result tags from assistant replies so that the conversation is easier to read.
 
 - Changing an email status while a scan is running persists when the task status is fetched. (TODO)
 
+
+#### User Story: Detailed scan progress (TODO)
+
+**Description:** As a user, I want to see progress while the whitelist and ignore lists are fetched so I know the scan is still running.
+
+**Test Scenarios:**
+
+- Progress text updates while fetching whitelist emails. (TODO)
+- Progress text updates while fetching ignore emails. (TODO)
+- Confirm button shows a "confirming" state until the server responds. (TODO)

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -54,3 +54,5 @@
 - Closed tasks are removed from server memory once confirmed.
 - Confirm action now clears email list in the UI.
 
+- Display progress while fetching whitelist and ignore lists.
+- Confirm button disables and shows progress during API call.

--- a/backend/app.py
+++ b/backend/app.py
@@ -256,9 +256,14 @@ def scan_emails():
             ignore_label = get_label_id(service, "spam-filter-ignore")
             # gather whitelisted senders
             logger.debug("Gmail request: list whitelist emails")
+            tasks[task_id]["stage"] = "listing whitelist emails"
             wmsgs = list_all_messages(service, q="label:whitelist")
+            tasks[task_id]["stage"] = "fetching whitelist emails"
+            tasks[task_id]["progress"] = 0
+            tasks[task_id]["total"] = len(wmsgs)
             if wmsgs:
                 for idx, m in enumerate(wmsgs):
+                    tasks[task_id]["progress"] = idx + 1
                     logger.debug("Gmail request: get message %s for whitelist", m["id"])
                     md = (
                         service.users()
@@ -284,9 +289,14 @@ def scan_emails():
 
             # gather ignored senders
             logger.debug("Gmail request: list ignore emails")
+            tasks[task_id]["stage"] = "listing ignore emails"
             imsgs = list_all_messages(service, q="label:spam-filter-ignore")
+            tasks[task_id]["stage"] = "fetching ignore emails"
+            tasks[task_id]["progress"] = 0
+            tasks[task_id]["total"] = len(imsgs)
             if imsgs:
                 for idx, m in enumerate(imsgs):
+                    tasks[task_id]["progress"] = idx + 1
                     logger.debug("Gmail request: get message %s for ignore", m["id"])
                     md = (
                         service.users()
@@ -606,6 +616,7 @@ def confirm():
             update_task_email_status(msg_id, "spam")
         except Exception:
             import traceback
+
             logger.error(traceback.format_exc())
     if task_id and task_id in tasks:
         # CODEX: Remove task so it no longer appears in active list


### PR DESCRIPTION
## Summary
- update backend progress when fetching whitelist and ignore lists
- show progress as `(current/total)` in frontend
- disable confirm button and show `Confirming...` while waiting for response
- document detailed progress user story
- log latest changes

## User Stories Implemented
- Detailed scan progress

## Affected Files
- `backend/app.py`
- `frontend/src/main.jsx`
- `PROJECT_BACKLOG.md`
- `WORK_LOG.md`

## Known Side Effects
- ESLint fails because no configuration file is present

## Testing
- `black backend/app.py`
- `flake8 backend/app.py`
- `npx prettier -w frontend/src/main.jsx`
- `npx eslint frontend/src/main.jsx` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68600527f8a0832ba567074dc4d7a713