### PR TITLE
CODEX: [Feature] Link emails to Gmail

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -166,8 +166,8 @@ reliably fetched.
 
 #### User Story: Deep link to Gmail messages (DONE)
 
-**Description:** As a user, I want to open the original email in Gmail by tapping the sender or subject so that I can review the full message easily.
+**Description:** As a user, I want to open the original email in Gmail by tapping the email entry so that I can review the full message easily.
 
 **Test Scenarios:**
 
-- The sender and subject columns link directly to the Gmail message. (TODO)
+- The email column links directly to the Gmail message with the subject below the sender. (TODO)

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -154,7 +154,6 @@ reliably fetched.
 
 - Changing an email status while a scan is running persists when the task status is fetched. (TODO)
 
-
 #### User Story: Detailed scan progress (TODO)
 
 **Description:** As a user, I want to see progress while the whitelist and ignore lists are fetched so I know the scan is still running.
@@ -164,3 +163,11 @@ reliably fetched.
 - Progress text updates while fetching whitelist emails. (TODO)
 - Progress text updates while fetching ignore emails. (TODO)
 - Confirm button shows a "confirming" state until the server responds. (TODO)
+
+#### User Story: Deep link to Gmail messages (DONE)
+
+**Description:** As a user, I want to open the original email in Gmail by tapping the sender or subject so that I can review the full message easily.
+
+**Test Scenarios:**
+
+- The sender and subject columns link directly to the Gmail message. (TODO)

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -83,3 +83,4 @@
 
 - Added Gmail deep links to sender and subject columns in the email list.
 - Documented new user story for deep linking in PROJECT_BACKLOG.md.
+- Combined sender and subject into one email column with a direct Gmail link.

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -71,6 +71,7 @@
 - Moved confirm button and controls to sticky header.
 - Removed chat window and added expandable LLM info per email.
 - Updated PROJECT_BACKLOG and stylesheets.
+
 ## 1st July 2025
 
 - Configured backend to load OpenRouter key from env or file and removed save key endpoint.
@@ -78,3 +79,7 @@
 - Added status filter buttons and tightened header spacing.
 - Updated README and backlog.
 
+## 5th July 2025
+
+- Added Gmail deep links to sender and subject columns in the email list.
+- Documented new user story for deep linking in PROJECT_BACKLOG.md.

--- a/backend/app.py
+++ b/backend/app.py
@@ -557,6 +557,7 @@ def scan_emails():
                             "subject": subject,
                             "sender": sender,
                             "date": date,
+                            "url": f"https://mail.google.com/mail/u/0/#inbox/{msg['id']}",
                             "status": status,
                             "request": text_md if llm_sent else "",
                             "response": answer if llm_sent else "",

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -22,15 +22,7 @@ function EmailRow({ email, onStatus }) {
             style={{ color: "inherit", textDecoration: "none" }}
           >
             {email.sender}
-          </a>
-        </td>
-        <td>
-          <a
-            href={email.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: "inherit", textDecoration: "none" }}
-          >
+            <br />
             {email.subject}
           </a>
         </td>
@@ -71,7 +63,7 @@ function EmailRow({ email, onStatus }) {
       </tr>
       {open && (
         <tr className="llm-details">
-          <td colSpan="4">
+          <td colSpan="3">
             <pre className="llm-request">{email.request}</pre>
             <pre className="llm-response">{email.response}</pre>
           </td>
@@ -241,8 +233,7 @@ function App() {
         <table>
           <thead>
             <tr>
-              <th>Sender</th>
-              <th>Subject</th>
+              <th>Email</th>
               <th>Date</th>
               <th>Action</th>
             </tr>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -14,8 +14,26 @@ function EmailRow({ email, onStatus }) {
   return (
     <>
       <tr className={`status-${email.status}`}>
-        <td>{email.sender}</td>
-        <td>{email.subject}</td>
+        <td>
+          <a
+            href={email.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "inherit", textDecoration: "none" }}
+          >
+            {email.sender}
+          </a>
+        </td>
+        <td>
+          <a
+            href={email.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "inherit", textDecoration: "none" }}
+          >
+            {email.subject}
+          </a>
+        </td>
         <td>{email.date}</td>
         <td className="actions">
           <button


### PR DESCRIPTION
## Summary
- add Gmail web links to message data
- make sender and subject columns clickable
- document deep link feature
- log today's work

## User Stories
- Deep link to Gmail messages (DONE)

## Modified Files
- `backend/app.py`
- `frontend/src/main.jsx`
- `PROJECT_BACKLOG.md`
- `WORK_LOG.md`

## Side Effects
- none

## Testing
- `flake8 backend/app.py`
- `black backend/app.py`
- `npx prettier -w frontend/src/main.jsx PROJECT_BACKLOG.md WORK_LOG.md frontend/src/App.css frontend/index.html`


------
https://chatgpt.com/codex/tasks/task_e_6868ca591394832bb43564dbd73f486c