### PR TITLE
CODEX: [Feature] reuse scanned emails

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -245,3 +245,11 @@ labels remain accessible.
 - Gmail API requests are logged at debug level. (TODO)
 - Task stage in the database updates as progress occurs. (TODO)
 
+#### User Story: Reuse unconfirmed email data (TODO)
+
+**Description:** As a user, I want emails that were scanned previously but not confirmed to appear in new scans so I can update their status without rescanning them. The system should also record when a spam filter has been created for a sender.
+
+**Test Scenarios:**
+- Scanning with a date range that overlaps previous scans lists those unconfirmed emails. (TODO)
+- Creating a filter that already exists marks the email as having the filter created. (TODO)
+

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -134,3 +134,10 @@
 - /scan-tasks no longer returns closed tasks.
 - Updated backlog scenarios for closed task filtering and confirmed email handling.
 - Fixed confirm worker to store user_id before starting thread.
+
+## 6th July 2025
+
+- Extended `email_status` table to store subject, sender, date and whether a spam filter exists.
+- Scan worker now loads unconfirmed emails from the database for the chosen date range and skips rescanning them.
+- Confirm process checks for existing filters, handles "already exists" errors and updates the new `filter_created` flag.
+- Added new user story about reusing unconfirmed email data.

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -32,5 +32,9 @@ CREATE TABLE IF NOT EXISTS email_status (
     email_id TEXT NOT NULL,
     status TEXT NOT NULL,
     confirmed INTEGER DEFAULT 0,
+    subject TEXT,
+    sender TEXT,
+    date TEXT,
+    filter_created INTEGER DEFAULT 0,
     PRIMARY KEY (user_id, email_id)
 );


### PR DESCRIPTION
## Summary
- persist subject, sender, date and filter_created in `email_status`
- skip rescanning unconfirmed emails and display them in new scans
- mark emails when a spam filter already exists for the sender
- backlog and work log updates

## User Stories
- Reuse unconfirmed email data

## Modified Files
- `backend/schema.sql`
- `backend/database.py`
- `backend/app.py`
- `PROJECT_BACKLOG.md`
- `WORK_LOG.md`

## Testing
- `black backend`
- `flake8 backend`


------
https://chatgpt.com/codex/tasks/task_e_686a1e778214832b81365a7b67cec184