### PR TITLE
CODEX: [Fix] stop using scan-persist label

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -253,3 +253,12 @@ labels remain accessible.
 - Scanning with a date range that overlaps previous scans lists those unconfirmed emails. (TODO)
 - Creating a filter that already exists marks the email as having the filter created. (TODO)
 
+#### User Story: Track scanned emails in the database (DONE)
+
+**Description:** As a developer, I want scanned email IDs stored in the database instead of applying the `scan-persist` Gmail label so the inbox view remains clean.
+
+**Test Scenarios:**
+
+- Scanning emails does not add the `scan-persist` label. (TODO)
+- Emails already stored in `email_status` are skipped on subsequent scans. (TODO)
+

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -141,3 +141,4 @@
 - Scan worker now loads unconfirmed emails from the database for the chosen date range and skips rescanning them.
 - Confirm process checks for existing filters, handles "already exists" errors and updates the new `filter_created` flag.
 - Added new user story about reusing unconfirmed email data.
+- Removed `scan-persist` Gmail label and store scanned IDs in database.

--- a/backend/database.py
+++ b/backend/database.py
@@ -158,7 +158,10 @@ def save_email_status(
             if filter_created is None:
                 filter_created = row["filter_created"]
         conn.execute(
-            "REPLACE INTO email_status (user_id, email_id, status, confirmed, subject, sender, date, filter_created) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "REPLACE INTO email_status (user_id, email_id, status, confirmed, "
+                "subject, sender, date, filter_created) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+            ),
             (
                 user_id,
                 email_id,


### PR DESCRIPTION
## Summary
- rely on database records instead of Gmail `scan-persist` label
- update email fetching queries and status updates
- document new user story for tracking scanned emails

## User Stories
- Track scanned emails in the database (DONE)

## Changes
- `backend/app.py`
- `backend/database.py`
- `PROJECT_BACKLOG.md`
- `WORK_LOG.md`

## Testing
- `black backend/app.py backend/database.py`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_686a469bfadc832b822cdf6cf0c56488