### PR TITLE
CODEX: [Fix] ensure single task record

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -176,6 +176,7 @@ reliably fetched.
 
 - Reloading the page after a scan finishes still shows the results until I click confirm. (TODO)
 - Closed tasks are not returned when fetching active tasks. (DONE)
+- Only the most recent active task is returned when fetching active tasks. (DONE)
 
 #### User Story: Persist manual status updates during scans (DONE)
 

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -143,3 +143,8 @@
 - Added new user story about reusing unconfirmed email data.
 - Removed `scan-persist` Gmail label and store scanned IDs in database.
 - Fixed timezone handling in `get_unconfirmed_emails` to prevent runtime errors.
+## 7th July 2025
+
+- Fixed tasks table to update existing rows by storing task id in memory.
+- Added database helper to load the latest active task and updated /scan-tasks to return only that task.
+- Updated backlog with scenario for latest active task filtering.

--- a/backend/database.py
+++ b/backend/database.py
@@ -100,6 +100,7 @@ def load_tasks(user_id: str):
             result.append(
                 {
                     "id": r["id"],
+                    "user_id": r["user_id"],
                     "stage": r["stage"],
                     "progress": r["progress"],
                     "total": r["total"],
@@ -108,6 +109,26 @@ def load_tasks(user_id: str):
                 }
             )
         return result
+
+
+def load_latest_task(user_id: str):
+    """Return the most recent task that is not closed."""
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT * FROM tasks WHERE user_id = ? AND stage != 'closed' ORDER BY rowid DESC LIMIT 1",
+            (user_id,),
+        ).fetchone()
+        if not row:
+            return None
+        return {
+            "id": row["id"],
+            "user_id": row["user_id"],
+            "stage": row["stage"],
+            "progress": row["progress"],
+            "total": row["total"],
+            "emails": json.loads(row["emails_json"] or "[]"),
+            "log": json.loads(row["log_json"] or "[]"),
+        }
 
 
 def delete_task(task_id: str) -> None:


### PR DESCRIPTION
## Summary
- keep task id in memory so updates reuse the existing DB row
- load only the latest active task for a user
- /scan-tasks now returns at most one task
- document latest-task scenario
- log work on 7th July 2025

## User Stories
- _Keep results after scan completes_

## Affected Files
- `backend/app.py`
- `backend/database.py`
- `PROJECT_BACKLOG.md`
- `WORK_LOG.md`

## Known Side Effects
- none

## Testing
- `black backend/app.py backend/database.py`
- `flake8 backend`
- `npx prettier -w frontend`
- `npx eslint frontend/src` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_686a550f0ffc832bb20075dc4db38972