### PR TITLE
CODEX: [Fix] polling for active scan task

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -148,3 +148,5 @@
 - Fixed tasks table to update existing rows by storing task id in memory.
 - Added database helper to load the latest active task and updated /scan-tasks to return only that task.
 - Updated backlog with scenario for latest active task filtering.
+- Frontend now continues polling when an active task is found on load and stops cleanly when tasks are closed.
+- Status polling now kicks off immediately when an active task is loaded.


### PR DESCRIPTION
## Summary
- start polling immediately when an active task is loaded
- update work log

## User Stories
- Resume active scan tasks

## Modified Files
- `frontend/src/main.jsx`
- `WORK_LOG.md`

## Side Effects
- none

## Testing
- `black backend`
- `flake8 backend`
- `npx prettier --write frontend/src/main.jsx`


------
https://chatgpt.com/codex/tasks/task_e_686a7beadcb0832b8cdb8ca51b93ca15