### PR TITLE
CODEX: [Feature] task-aware button controls

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -278,3 +278,13 @@ labels remain accessible.
 **Test Scenarios:**
 - Email IDs already in `email_status` are not fetched again from Gmail. (TODO)
 
+#### User Story: Action buttons depend on task state (TODO)
+
+**Description:** As a user, I want the scan, confirm and refresh buttons to appear only when it makes sense so I don't start conflicting tasks.
+
+**Test Scenarios:**
+- Confirm button only shows when the latest task is done. (TODO)
+- Scan Emails button hides if any task is running. (TODO)
+- Refresh Lists button hides during a scan task. (TODO)
+- Scan Emails and Confirm hide during a refresh task. (TODO)
+

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -158,3 +158,10 @@
 - Frontend gained a "Refresh Lists" button to trigger the new task.
 - Documented new user story for refreshing sender lists.
 - Added database helper to list all email IDs and skipped them when refreshing sender lists.
+
+## 9th July 2025
+
+- Added kind field for tasks in memory to distinguish scan and refresh operations.
+- Frontend buttons now hide or show based on task state.
+- Backend loads latest task kind by inspecting stage text.
+- Documented new user story for task-based button visibility.

--- a/backend/app.py
+++ b/backend/app.py
@@ -392,7 +392,7 @@ def fetch_label_senders(
             "",
         )
         database.save_sender(user_id, sender, status)
-        #database.save_email_status(user_id, msg_id, status, confirmed=True)
+        # database.save_email_status(user_id, msg_id, status, confirmed=True)
 
 
 @app.route("/scan-emails", methods=["POST"])
@@ -418,6 +418,7 @@ def scan_emails():
         "total": 0,
         "emails": [],
         "log": [],
+        "kind": "scan",
     }
     database.save_task(
         {
@@ -428,6 +429,7 @@ def scan_emails():
             "total": 0,
             "emails": [],
             "log": [],
+            "kind": "scan",
         }
     )
     logger.info("Starting scan task %s for last %s days", task_id, days)
@@ -713,6 +715,7 @@ def refresh_senders():
         "total": 0,
         "emails": [],
         "log": [],
+        "kind": "refresh",
     }
     database.save_task(tasks[task_id])
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -2,6 +2,7 @@ import os
 import json
 import sqlite3
 import datetime
+import re
 from email.utils import parsedate_to_datetime
 
 DB_PATH = os.path.join(os.path.dirname(__file__), "data.db")
@@ -120,7 +121,7 @@ def load_latest_task(user_id: str):
         ).fetchone()
         if not row:
             return None
-        return {
+        task = {
             "id": row["id"],
             "user_id": row["user_id"],
             "stage": row["stage"],
@@ -129,6 +130,11 @@ def load_latest_task(user_id: str):
             "emails": json.loads(row["emails_json"] or "[]"),
             "log": json.loads(row["log_json"] or "[]"),
         }
+        if re.search(r"whitelist|spam emails|ignore emails", task["stage"], re.I):
+            task["kind"] = "refresh"
+        else:
+            task["kind"] = "scan"
+        return task
 
 
 def delete_task(task_id: str) -> None:

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -278,6 +278,10 @@ function App() {
       });
   };
 
+  const isRefreshTask =
+    task && /whitelist|spam emails|ignore emails/i.test(task.stage || "");
+  const isScanningTask = task && !isRefreshTask;
+
   return (
     <div className="container">
       <header className="header">
@@ -301,8 +305,10 @@ function App() {
             onChange={(e) => setDays(e.target.value)}
           />
         </div>
-        <button onClick={scan}>Scan Emails</button>
-        <button onClick={refreshLists}>Refresh Lists</button>
+        {!task && <button onClick={scan}>Scan Emails</button>}
+        {!isScanningTask && (
+          <button onClick={refreshLists}>Refresh Lists</button>
+        )}
         {task && task.stage !== "done" && (
           <div className="progress">
             <div>
@@ -311,9 +317,11 @@ function App() {
             <progress value={task.progress} max={task.total || 1}></progress>
           </div>
         )}
-        <button onClick={confirm} disabled={confirming}>
-          {confirming ? "Confirming..." : "Confirm"}
-        </button>
+        {task && task.stage === "done" && !isRefreshTask && (
+          <button onClick={confirm} disabled={confirming}>
+            {confirming ? "Confirming..." : "Confirm"}
+          </button>
+        )}
       </header>
       <div className="filters">
         <button


### PR DESCRIPTION
## Summary
- hide or show buttons based on current task
- mark tasks with kind and infer kind when loading
- update backlog with button visibility story
- record work in log

## User Stories
- Action buttons depend on task state

## Modified Files
- `frontend/src/main.jsx`
- `backend/app.py`
- `backend/database.py`
- `PROJECT_BACKLOG.md`
- `WORK_LOG.md`

## Known Side Effects
- none

## Testing
- `black backend`
- `flake8 backend`
- `npx prettier -w frontend/src/main.jsx`


------
https://chatgpt.com/codex/tasks/task_e_686e01f18c58832b89b665855fda37b0