### PR TITLE
CODEX: Fix status revert during scan

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -143,6 +143,7 @@
 - Added new user story about reusing unconfirmed email data.
 - Removed `scan-persist` Gmail label and store scanned IDs in database.
 - Fixed timezone handling in `get_unconfirmed_emails` to prevent runtime errors.
+
 ## 7th July 2025
 
 - Fixed tasks table to update existing rows by storing task id in memory.
@@ -174,3 +175,5 @@
 - Updated whitelist search link to use an Android intent and fall back to the Gmail web client on iOS and desktop.
 - Reverted all Gmail links to open the web client regardless of platform.
 - Updated backlog to reflect web-only Gmail links.
+  \n## 10th July 2025
+- Fixed status flicker when updating emails during scan by ignoring server updates for 5 seconds.


### PR DESCRIPTION
## Summary
- ignore incoming status for recently changed emails
- keep track of pending status updates with a ref
- document the fix in the work log

## User Stories
- Persist manual status updates during scans (DONE)

## Files Affected
- `frontend/src/main.jsx`
- `WORK_LOG.md`

## Known Side Effects
- none

## Testing
- `black backend`
- `flake8 backend` *(fails: command not found)*
- `npx prettier -w frontend/src/main.jsx`
- `npx eslint frontend/src/main.jsx` *(fails: config not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f541931c8832b8f4e5c76680172f6