### PR TITLE
CODEX: [Fix] sort scan results by date

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -261,6 +261,13 @@ labels remain accessible.
 **Test Scenarios:**
 - Emails returned from `/scan-status/<id>` are ordered by their received date regardless of when they were scanned. (DONE)
 
+#### User Story: Prevent duplicate scan results (DONE)
+
+**Description:** As a user, I want each email to appear only once in the list even when data comes from both the current scan and the database.
+
+**Test Scenarios:**
+- `/scan-status/<id>` never returns the same email id twice. (DONE)
+
 #### User Story: Track scanned emails in the database (DONE)
 
 **Description:** As a developer, I want scanned email IDs stored in the database instead of applying the `scan-persist` Gmail label so the inbox view remains clean.

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -179,3 +179,4 @@
 - Fixed status flicker when updating emails during scan by ignoring server updates for 5 seconds.
 - Added unconfirmed emails from database to /scan-status results.
 - Sorted scan status emails by date to mix old and new results correctly.
+- Deduplicated unconfirmed emails during scans and in scan status results (Prevent duplicate scan results).


### PR DESCRIPTION
## Summary
- include all unconfirmed emails in scan status and sort them by date
- add user story for ordered scan results
- log today's sorting update

## User Stories
- Reuse unconfirmed email data
- Sort scan results by date

## Modified Files
- `backend/app.py`
- `PROJECT_BACKLOG.md`
- `WORK_LOG.md`

## Side Effects
- none

## Testing
- `black backend/app.py`
- `flake8 backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_686f5bf52630832b93e049432968752c