### PR TITLE
CODEX: [Feature] Manage sender list

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -310,3 +310,13 @@ labels remain accessible.
 **Test Scenarios:**
 - Clicking the link opens Gmail showing `label:whitelist` results in the web client on any platform. (TODO)
 
+#### User Story: Manage sender list (TODO)
+
+**Description:** As a user, I want to view and remove senders flagged as whitelist, spam or ignore so I can correct mistakes.
+
+**Test Scenarios:**
+
+- Manage page lists senders for each status. (TODO)
+- Filter buttons show only whitelist, spam or ignore senders. (TODO)
+- Clicking the trashcan removes the sender and unconfirms related emails. (TODO)
+

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -180,3 +180,4 @@
 - Added unconfirmed emails from database to /scan-status results.
 - Sorted scan status emails by date to mix old and new results correctly.
 - Deduplicated unconfirmed emails during scans and in scan status results (Prevent duplicate scan results).
+- Added sender management page with backend APIs to list and reset senders.

--- a/backend/app.py
+++ b/backend/app.py
@@ -984,5 +984,22 @@ def confirm():
     return ("", 202)
 
 
+@app.route("/senders")
+def list_senders():
+    """Return list of senders and their status."""
+    senders = database.list_senders(g.user_id)
+    return jsonify({"senders": senders})
+
+
+@app.route("/reset-sender", methods=["POST"])
+def reset_sender():
+    """Remove a sender from spam/whitelist/ignore lists."""
+    sender = request.json.get("sender")
+    if not sender:
+        return jsonify({"error": "missing sender"}), 400
+    database.clear_sender(g.user_id, sender)
+    return ("", 204)
+
+
 if __name__ == "__main__":
     app.run(debug=True, ssl_context="adhoc")

--- a/backend/database.py
+++ b/backend/database.py
@@ -297,3 +297,27 @@ def get_all_email_ids(user_id: str):
             (user_id,),
         ).fetchall()
         return [r["email_id"] for r in rows]
+
+
+def list_senders(user_id: str):
+    """Return all senders and their status for the given user."""
+    with get_connection() as conn:
+        rows = conn.execute(
+            "SELECT sender, status FROM senders WHERE user_id = ?",
+            (user_id,),
+        ).fetchall()
+        return [{"sender": r["sender"], "status": r["status"]} for r in rows]
+
+
+def clear_sender(user_id: str, sender: str) -> None:
+    """Remove sender from list and delete related email statuses."""
+    with get_connection() as conn:
+        conn.execute(
+            "DELETE FROM senders WHERE user_id = ? AND sender = ?",
+            (user_id, sender),
+        )
+        conn.execute(
+            "DELETE FROM email_status WHERE user_id = ? AND sender = ?",
+            (user_id, sender),
+        )
+        conn.commit()

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -158,6 +158,13 @@ button.ignore {
   height: 24px;
   padding: 0;
 }
+.trash-btn {
+  background: #eee;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+}
 .progress {
   margin: 10px 0;
 }


### PR DESCRIPTION
## Summary
- add DB helpers for listing and clearing senders
- expose `/senders` and `/reset-sender` API endpoints
- add manage page in React to view and remove senders
- style trashcan button
- document sender management user story
- log today's work

## User Stories
- Manage sender list (TODO)

## Testing
- `black backend/app.py backend/database.py`
- `flake8 backend/app.py backend/database.py`
- `npx prettier --write frontend/src/main.jsx frontend/src/App.css`
- `npx eslint frontend/src/main.jsx` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_686f6de2b0b8832bb21ea1a8062ff9fd