### PR TITLE
CODEX: [Feature] add log viewer and task cleanup

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -320,3 +320,13 @@ labels remain accessible.
 - Filter buttons show only whitelist, spam or ignore senders. (TODO)
 - Clicking the trashcan removes the sender and unconfirms related emails. (TODO)
 
+#### User Story: View task logs and clear tasks (TODO)
+
+**Description:** As a user, I want to see backend logs for my account and remove stuck tasks so I can troubleshoot issues.
+
+**Test Scenarios:**
+
+- Clicking "View Logs" shows log lines since the last restart. (TODO)
+- Clicking "Clear Task" removes the current task from the UI and database. (TODO)
+- `/scan-status/<id>` returns a summary when a task completes so the UI can alert me. (TODO)
+

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -181,3 +181,7 @@
 - Sorted scan status emails by date to mix old and new results correctly.
 - Deduplicated unconfirmed emails during scans and in scan status results (Prevent duplicate scan results).
 - Added sender management page with backend APIs to list and reset senders.
+\n## 12th July 2025
+- Added log viewing and task clearing features with backend APIs.
+- UI now has View Logs and Clear Task buttons.
+- Completed tasks return a summary from /scan-status.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -180,3 +180,16 @@ button.ignore {
 .gmail-link:hover {
   text-decoration: underline;
 }
+
+.logs-dialog {
+  position: fixed;
+  top: 10%;
+  left: 10%;
+  right: 10%;
+  bottom: 10%;
+  background: #fff;
+  border: 1px solid #ccc;
+  overflow: auto;
+  padding: 10px;
+  z-index: 100;
+}


### PR DESCRIPTION
## Summary
- store logs per user and allow viewing from the UI
- allow clearing broken tasks
- return task completion summaries from `/scan-status/<id>`
- add View Logs and Clear Task buttons
- document new user story

## User Stories Implemented
- View task logs and clear tasks

## Known Side Effects
- none

## Testing
- `black backend`
- `flake8 backend`
- `npx prettier -w frontend/src/main.jsx frontend/src/App.css`

------
https://chatgpt.com/codex/tasks/task_e_6871f3119214832b99d5a7ad21f20383