### PR TITLE
CODEX: [Feature] Store unconfirmed emails from refresh

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -302,6 +302,7 @@ labels remain accessible.
 **Test Scenarios:**
 
 - Email IDs already in `email_status` are not fetched again from Gmail. (TODO)
+- New emails with labels are stored in `email_status` with `confirmed = 0`. (TODO)
 
 #### User Story: Action buttons depend on task state (DONE)
 

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -194,3 +194,4 @@
 
 - Added proxy configuration for new log and task APIs.
 - Fixed crash when clearing a running task by checking task existence before updating.
+- Refresh tasks now save unseen emails in `email_status` as unconfirmed to skip re-fetches.

--- a/backend/app.py
+++ b/backend/app.py
@@ -431,7 +431,13 @@ def fetch_label_senders(
             "",
         )
         database.save_sender(user_id, sender, status)
-        # database.save_email_status(user_id, msg_id, status, confirmed=True)
+        database.save_email_status_if_absent(
+            user_id,
+            msg_id,
+            status,
+            confirmed=False,
+            sender=sender,
+        )
 
 
 @app.route("/scan-emails", methods=["POST"])
@@ -713,7 +719,13 @@ def scan_emails():
             )
         except Exception:
             import traceback
-            logger.error("Exception occurred during scan task: %s - %s", task_id, traceback.format_exc(), exc_info=True)
+
+            logger.error(
+                "Exception occurred during scan task: %s - %s",
+                task_id,
+                traceback.format_exc(),
+                exc_info=True,
+            )
 
             print(traceback.format_exc())
         finally:


### PR DESCRIPTION
## Summary
- skip fetches for sender refresh by storing unseen email IDs
- note refresh storage in the project backlog
- log the change in the work log

## User Stories
- Skip duplicate sender fetches

## Components Affected
- backend/app.py
- backend/database.py
- PROJECT_BACKLOG.md
- WORK_LOG.md

## Known Side Effects
- none

## Testing
- `flake8`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_68735171efd8832ba03b55dd4aaccaed