### PR TITLE
CODEX: [Fix] remove confirmed emails during confirming

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -234,6 +234,14 @@ labels remain accessible.
 - Task stage switches to "confirming" when the confirm button is pressed. (DONE)
 - Progress increases as each email is confirmed. (DONE)
 
+#### User Story: Hide confirmed emails during confirmation (DONE)
+
+**Description:** As a user, I want emails to disappear from the list as they are confirmed so that I can't change their status once processing has finished.
+
+**Test Scenarios:**
+
+- Polling `/scan-status/<id>` excludes emails that have already been confirmed. (DONE)
+
 #### User Story: Reset the database (TODO)
 
 **Description:** As a developer, I want a simple script to clear the SQLite database so I can start fresh during testing.

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -205,3 +205,4 @@
 - Filtered /logs request and response entries from the log viewer results.
 - Fixed filtering to exclude the /logs response payload lines.
 - Adjusted filtering for log payload lines without the slash.
+- Removed confirmed emails from /scan-status results.

--- a/backend/app.py
+++ b/backend/app.py
@@ -798,6 +798,10 @@ def scan_status(task_id):
         for email in task.get("emails", []):
             unique[email["id"]] = email
         task["emails"] = list(unique.values())
+        # CODEX: drop any emails that have been confirmed already
+        unconfirmed_ids = {e["id"] for e in existing}
+        task["emails"] = [e for e in task["emails"] if e["id"] in unconfirmed_ids]
+        tasks[task_id]["emails"] = task["emails"]
 
         # CODEX: Sort emails by date so reused entries are merged in order
         def _email_dt(email):


### PR DESCRIPTION
## Summary
- filter out confirmed emails from `/scan-status` results
- document new user story for removing confirmed emails from the UI
- log the change in `WORK_LOG.md`

## User Stories
- Hide confirmed emails during confirmation (DONE)

## Affected Files
- `backend/app.py`
- `PROJECT_BACKLOG.md`
- `WORK_LOG.md`

## Known Side Effects
- None

## Testing
- `flake8 backend`


------
https://chatgpt.com/codex/tasks/task_e_6875fbea27c0832b94332a445d14dd7b