### PR TITLE
CODEX: [Feature] Match sender list row colors

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -341,6 +341,7 @@ labels remain accessible.
 - Manage page lists senders for each status. (TODO)
 - Filter buttons show only whitelist, spam or ignore senders. (TODO)
 - Clicking the trashcan removes the sender and unconfirms related emails. (TODO)
+- Sender rows use the same colour-coded backgrounds as the email list. (TODO)
 
 #### User Story: View task logs and clear tasks (DONE)
 

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -195,10 +195,13 @@
 - Added proxy configuration for new log and task APIs.
 - Fixed crash when clearing a running task by checking task existence before updating.
 - Refresh tasks now save unseen emails in `email_status` as unconfirmed to skip re-fetches.
+
 ## 14th July 2025
+
 - Added automatic request and response logging via Flask hooks. Added debug log for email classification decisions.
 
 ## 15th July 2025
+
 - Wrapped log lines to avoid horizontal scrolling.
 - Logs dialog now polls every second and scrolls to the bottom when open.
 - Updated backlog with new log viewer scenarios.
@@ -212,3 +215,5 @@
 - /logs requests no longer fill the log buffer.
 - Updated backlog to mark the log filtering scenario as done.
 - Skipped request and response logging for the /logs endpoint.
+
+- Colour-coded sender rows in ManageSenders list.

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -159,7 +159,7 @@ function ManageSenders({ onClose }) {
           </thead>
           <tbody>
             {filtered.map((s) => (
-              <tr key={s.sender}>
+              <tr key={s.sender} className={`status-${s.status}`}>
                 <td className="email-cell">{s.sender}</td>
                 <td>{s.status}</td>
                 <td className="actions">


### PR DESCRIPTION
## Summary
- colour-code sender rows in Manage page
- document colour coding scenario in backlog
- log work

## User Stories
- Manage sender list

## Modified Files
- `frontend/src/main.jsx`
- `PROJECT_BACKLOG.md`
- `WORK_LOG.md`

## Side Effects
- none

## Testing
- `black backend`
- `flake8 backend`
- `npx prettier -w frontend/src/main.jsx frontend/src/App.css`
- `npx eslint frontend/src/main.jsx` *(fails: eslint config missing)*


------
https://chatgpt.com/codex/tasks/task_e_687736615008832bb2ea259211c55e6c